### PR TITLE
Feature: local postgresql running

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+elifeFormula('elife-dashboard')

--- a/salt/elife-dashboard/scheduler.sls
+++ b/salt/elife-dashboard/scheduler.sls
@@ -33,10 +33,12 @@ install-{{ app.name }}:
 
 # ensure local postgresql is running
 # when an rds instance is detected, the local service is stopped
+# article-scheduler is an exception to that rule
 extend:
     postgresql:
         service:
             - running
+            - enable: True
 
 {{ app.name }}-db-user:
     postgres_user.present:

--- a/salt/elife-dashboard/scheduler.sls
+++ b/salt/elife-dashboard/scheduler.sls
@@ -31,6 +31,13 @@ install-{{ app.name }}:
 # db
 #
 
+# ensure local postgresql is running
+# when an rds instance is detected, the local service is stopped
+extend:
+    postgresql:
+        service:
+            - running
+
 {{ app.name }}-db-user:
     postgres_user.present:
         - name: {{ app.db.username }}


### PR DESCRIPTION
article-scheduler is an exception to the rule "don't run a local psql instance if an rds instance is detected". 

this ensures psql is running for article-scheduler even if RDS is detected