### PR TITLE
explicit step to install elife-article-scheduler repo

### DIFF
--- a/salt/elife-dashboard/scheduler.sls
+++ b/salt/elife-dashboard/scheduler.sls
@@ -5,11 +5,17 @@ install-{{ app.name }}:
     git.latest:
         - name: ssh://git@github.com/elifesciences/{{ app.name }}
         - identity: {{ pillar.elife.projects_builder.key or '' }}
+
         # note: elife-article-scheduler is always deployed as master
         # until it has its own instance, we cannot a revision
         # using build vars
-        - rev: {{ salt['elife.cfg']('project.branch', 'master') }}
-        - branch: {{ salt['elife.cfg']('project.branch', 'master') }}
+        # update 2017-10-30: the below aren't working as we expected because the
+        # values for project.branch on --continuumtest, --prod and --end2end 
+        # are 'develop'!
+        #- rev: {{ salt['elife.cfg']('project.branch', 'master') }}
+        #- branch: {{ salt['elife.cfg']('project.branch', 'master') }}
+        - rev: master
+        - branch: master
         - target: /srv/{{ app.name }}
         - force_fetch: True
         - force_checkout: True


### PR DESCRIPTION
this PR depends on: https://github.com/elifesciences/elife-article-scheduler/pull/1

I suspect I was previously relying on the cron job that runs every minute to install the venv if it wasn't present.

the cronjob now expects the project to be successfully installed and will skip calling pip.

branch and revision are now explicitly set to 'master' because the `project.branch` value on all instances of elife-dashboard is set to `develop`