### PR TITLE
re-enables /var/log/app.log logging

### DIFF
--- a/salt/elife-dashboard/config/etc-syslog-ng-conf.d-app.conf
+++ b/salt/elife-dashboard/config/etc-syslog-ng-conf.d-app.conf
@@ -22,7 +22,6 @@ source s_app_nginx_errors {
     ); 
 };
 
-{# comment #}
 source s_app_log {
     file("/var/log/app.log" 
          follow_freq(1)
@@ -33,14 +32,13 @@ source s_app_log {
          flags(no-parse) 
     ); 
 };
-{# endcomment #}
 
 
 {% if pillar.elife.logging.loggly.enabled %}
 log {
     source(s_app_nginx_access);
     source(s_app_nginx_errors);
-    {# comment #}source(s_app_log);{# endcomment #}
+    source(s_app_log);
     destination(d_loggly);
 };
 {% endif %}


### PR DESCRIPTION
It doesn't look like it's ever been enabled from the `blame`.

This will make `techalerts@elife...` noisier until these errors I'm seeing are fixed.